### PR TITLE
Deprecated SSM policy updates

### DIFF
--- a/modules/role/README.md
+++ b/modules/role/README.md
@@ -11,7 +11,7 @@ module "ec2_instance_role" {
   name        = "EC2InstanceRole"
   aws_service = ["ec2.amazonaws.com"]
 
-  policy_arns       = ["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
+  policy_arns       = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   policy_arns_count = 1
 
   inline_policy       = ["${data.aws_iam_policy_document.ec2_instance_policy.json}"]

--- a/modules/role/examples/ec2_instance_role.tf
+++ b/modules/role/examples/ec2_instance_role.tf
@@ -29,14 +29,8 @@ data "aws_iam_policy_document" "ec2_instance_policy" {
     effect = "Allow"
 
     actions = [
-      "cloudwatch:PutMetricData",
       "cloudwatch:GetMetricStatistics",
       "cloudwatch:ListMetrics",
-      "logs:CreateLogStream",
-      "ec2:DescribeTags",
-      "logs:DescribeLogStreams",
-      "logs:CreateLogGroup",
-      "logs:PutLogEvents",
       "ssm:GetParameter",
     ]
 
@@ -44,9 +38,18 @@ data "aws_iam_policy_document" "ec2_instance_policy" {
   }
 
   statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetEncryptionConfiguration",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
     effect    = "Allow"
-    actions   = ["ec2:DescribeTags"]
-    resources = ["*"]
+    resources = ["arn:aws:s3:::rackspace-*/*"]
   }
 }
 
@@ -56,8 +59,11 @@ module "ec2_instance_role" {
   name        = "EC2InstanceRole"
   aws_service = ["ec2.amazonaws.com"]
 
-  policy_arns       = ["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
-  policy_arns_count = 1
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+  ]
+  policy_arns_count = 2
 
   inline_policy       = [data.aws_iam_policy_document.ec2_instance_policy.json]
   inline_policy_count = 1

--- a/modules/role/main.tf
+++ b/modules/role/main.tf
@@ -12,7 +12,7 @@
 *   name        = "EC2InstanceRole"
 *   aws_service = ["ec2.amazonaws.com"]
 *
-*   policy_arns       = ["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
+*   policy_arns       = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
 *   policy_arns_count = 1
 *
 *   inline_policy       = ["${data.aws_iam_policy_document.ec2_instance_policy.json}"]

--- a/modules/ssm_service_roles/main.tf
+++ b/modules/ssm_service_roles/main.tf
@@ -70,10 +70,12 @@ module "automation_role" {
 
   policy_arns = [
     "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
   ]
 
-  policy_arns_count = 2
+  policy_arns_count = 4
 }
 
 # Since this policy references the IAM role itself, it must be created and attached after the role is created.
@@ -88,6 +90,21 @@ data "aws_iam_policy_document" "automation_policy" {
     actions   = ["iam:PassRole"]
     effect    = "Allow"
     resources = [module.automation_role.arn]
+  }
+
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetEncryptionConfiguration",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::rackspace-*/*"]
   }
 }
 

--- a/tests/cross_account_roles/main.tf
+++ b/tests/cross_account_roles/main.tf
@@ -105,10 +105,9 @@ module "ec2_instance_role" {
   name        = "EC2InstanceRole"
   aws_service = ["ec2.amazonaws.com"]
 
-  policy_arns       = ["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
+  policy_arns       = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
   policy_arns_count = 1
 
   inline_policy       = [data.aws_iam_policy_document.ec2_instance_policy.json]
   inline_policy_count = 1
 }
-


### PR DESCRIPTION
* Updated references to AmazonEC2RoleforSSM since it's deprecated
* Modified example to use the new managed ARNs and S3 permissions so it's a more practical example
* Modified automation service role to use the new managed ARNs and S3 permissions

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
