### PR TITLE
Remove deprecated `template_file` usage

### DIFF
--- a/modules/role/README.md
+++ b/modules/role/README.md
@@ -21,16 +21,37 @@ module "ec2_instance_role" {
 
 Full working references are available at [examples](examples)
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | aws | >= 2.7.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_instance_profile) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_role_policy) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_role_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws\_account | A list of AWS accounts allowed to use this cross account role.  Required if the aws\_services variable is not provided. | `list(string)` | `[]` | no |
 | aws\_service | A list of AWS services allowed to assume this role.  Required if the aws\_accounts variable is not provided. | `list(string)` | `[]` | no |
 | build\_state | A variable to control whether resources should be built | `bool` | `true` | no |
@@ -49,4 +70,3 @@ Full working references are available at [examples](examples)
 | id | IAM role id |
 | instance\_profile | IAM Instance Profile name |
 | name | IAM role name |
-

--- a/modules/role/examples/cross_account_role.tf
+++ b/modules/role/examples/cross_account_role.tf
@@ -1,14 +1,16 @@
+locals {
+  cross_account_vars = {
+    sns_topic = module.sns.topic_arn
+  }
+}
+
 terraform {
   required_version = ">= 0.12"
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
-}
-
-provider "template" {
-  version = "~> 2.0"
 }
 
 provider "random" {
@@ -28,14 +30,6 @@ module "sns" {
   name   = "my-example-topic"
 }
 
-data "template_file" "cross_account_role" {
-  template = file("${path.module}/cross_account_role_policy.json")
-
-  vars = {
-    sns_topic = module.sns.topic_arn
-  }
-}
-
 module "cross_account_role" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-iam_resources//modules/role?ref=v0.12.0"
 
@@ -43,6 +37,6 @@ module "cross_account_role" {
   aws_account = ["794790922771"]
   external_id = random_string.external_id.result
 
-  inline_policy       = [data.template_file.cross_account_role.rendered]
+  inline_policy       = [templatefile("${path.module}/cross_account_role_policy.json", local.cross_account_vars)]
   inline_policy_count = 1
 }

--- a/modules/role/examples/ec2_instance_role.tf
+++ b/modules/role/examples/ec2_instance_role.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/modules/role/examples/vpc_peering_role.tf
+++ b/modules/role/examples/vpc_peering_role.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/modules/ssm_service_roles/README.md
+++ b/modules/ssm_service_roles/README.md
@@ -17,16 +17,37 @@ module "ssm_service_roles" {
 
 Full working references are available at [examples](examples)
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | aws | >= 2.7.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| automation_role | ../role |  |
+| maintenance_window_role | ../role |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_role_policy) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | create\_automation\_role | A variable to control whether the Automation Service IAM role should be created | `bool` | `true` | no |
 | create\_maintenance\_window\_role | A variable to control whether the Maintenance Window Service IAM role should be created | `bool` | `true` | no |
 
@@ -43,4 +64,3 @@ Full working references are available at [examples](examples)
 | maintenance\_window\_instance\_profile | Maintenance Window IAM Instance Profile name |
 | maintenance\_window\_name | Maintenance Window IAM role name |
 | module\_details | All details about created SSM Service Roles |
-

--- a/modules/ssm_service_roles/examples/systems_manager_service_roles.tf
+++ b/modules/ssm_service_roles/examples/systems_manager_service_roles.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/modules/user_group/README.md
+++ b/modules/user_group/README.md
@@ -14,16 +14,36 @@ module "user_4" {
 
 Full working references are available at [examples](examples)
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | aws | >= 2.7.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_group](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_group) |
+| [aws_iam_group_membership](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_group_membership) |
+| [aws_iam_group_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_group_policy_attachment) |
+| [aws_iam_user](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_user) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | existing\_user\_names | A list of existing IAM users.  These users will also  be added to the created group. | `list(string)` | `[]` | no |
 | group\_name | The name to assign to the IAM Group created for these users.  If omitted no group will be created. | `string` | `""` | no |
 | policy\_arns | A list of managed IAM policies to attach to the IAM group | `list(string)` | `[]` | no |
@@ -38,4 +58,3 @@ Full working references are available at [examples](examples)
 | group\_id | IAM group id |
 | group\_name | IAM group name |
 | user\_names | The list of created IAM users |
-

--- a/modules/user_group/examples/users_and_groups.tf
+++ b/modules/user_group/examples/users_and_groups.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/tests/cross_account_roles/main.tf
+++ b/tests/cross_account_roles/main.tf
@@ -7,10 +7,6 @@ provider "aws" {
   region  = "us-west-2"
 }
 
-provider "template" {
-  version = "~> 2.0"
-}
-
 provider "random" {
   version = "~> 2.0"
 }
@@ -21,10 +17,6 @@ resource "random_string" "external_id" {
   min_upper   = 1
   min_lower   = 1
   min_numeric = 1
-}
-
-data "template_file" "cross_account_role" {
-  template = file("${path.module}/cross_account_role_policy.json")
 }
 
 data "aws_iam_policy_document" "vpc_peer_cross_account_role" {
@@ -42,7 +34,7 @@ module "cross_account_role" {
   aws_account = ["794790922771"]
   external_id = random_string.external_id.result
 
-  inline_policy       = [data.template_file.cross_account_role.rendered]
+  inline_policy       = [templatefile("${path.module}/cross_account_role_policy.json", {})]
   inline_policy_count = 1
 }
 


### PR DESCRIPTION
- `template_file` should no longer be used. `templatefile` function has replaced it.

##### Corresponding Issue(s):
 [MPCSUPENG-2862](https://rackspace.atlassian.net/browse/MPCSUPENG-3862)

##### Summary of change(s):
`data template_file` is deprecated. `templatefile` function has replaced.

##### Reason for Change(s):
Newer versions of TF do not have support for `template_file` especially if you are using a Mac with an M1 chip. The ARM version of TF will stop working if you are using versions higher than 0.15

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

It did not during tests.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?

##### Do examples need to be updated based on changes?

Yes. Updated.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
